### PR TITLE
Stop double done-callback call

### DIFF
--- a/tasks/main.js
+++ b/tasks/main.js
@@ -55,6 +55,7 @@ function sendToCoverallsCallback(done, err, response, body, force){
     }
     else {
       handleError(done, "Bad response:" + response.statusCode + " " + body, force);
+      return;
     }
   }
   done();


### PR DESCRIPTION
Fixes #16 (thanks to @yyx990803 for pointing it out)

When the error is handled there's no need to go on so exit early. Another option would be to add a `done()` to L55 and an `else` to L61 but that's more error prone IMHO.
